### PR TITLE
Invoke `curl` in a more secure way to download the `pants` script

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -9,7 +9,12 @@
 set -euo pipefail
 
 echo "Fetching latest 'pants' script"
-curl -L -o ./pants https://pantsbuild.github.io/setup/pants
+curl --proto "=https" \
+    --tlsv1.2 \
+    --location \
+    --verbose \
+    --output ./pants \
+    https://static.pantsbuild.org/setup/pants
 chmod a+x pants
 
 # Remove unused hook files and test files (because otherwise this is


### PR DESCRIPTION
Now that pantsbuild/setup#116 has been
addressed, we can force the use of HTTPS and TLS on this
particular download.

We use `--tlsv1.2` to provide a floor for which version of TLS to
use. If your `curl` has support for 1.3, it will use that. We're
leaving out TLS 1.0 and 1.1 because those have been deprecated as
insecure. Similarly, all SSL versions are deprecated, too.

(Internally, our developer workstations have support for TLS 1.3, but
we only have support for TLS 1.2 in our CI/CD system.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
