### PR TITLE
Use single quotes for a "raw" TOML string

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -13,10 +13,7 @@ backend_packages = [
 build_ignore = [
     # Don't want the BUILD files in the template to get treated as
     # though they applied to this project.
-    #
-    # NOTE: This currently causes the following warning:
-    #    DeprecationWarning: invalid escape sequence \{
-    "\\{\\{ cookiecutter.__repo_name \\}\\}"
+    '\\{\\{ cookiecutter.__repo_name \\}\\}'
 ]
 pants_ignore = [
     "!.buildkite/",


### PR DESCRIPTION
Previously, Pants was complaining about this escaped cookiecutter
templated directory:

    DeprecationWarning: invalid escape sequence \{

By switching from double quotes to single quotes, however, we can
treat this as a "raw" TOML string. We still have to have the escape
characters, but Pants no longer complains.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
