### PR TITLE
Update and lock Buildkite images

### DIFF
--- a/{{ cookiecutter.__repo_name }}/Makefile
+++ b/{{ cookiecutter.__repo_name }}/Makefile
@@ -1,4 +1,4 @@
-DOCKER_COMPOSE_CHECK := docker-compose run --rm
+DOCKER_COMPOSE_CHECK := docker compose run --rm
 PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants
 
 .DEFAULT_GOAL=all

--- a/{{ cookiecutter.__repo_name }}/README.md
+++ b/{{ cookiecutter.__repo_name }}/README.md
@@ -19,7 +19,7 @@ TODO
 
 ## Building and Contributing
 
-Requires `make`, `docker`, and `docker-compose`.
+Requires `make`, `docker`, and Docker Compose v2.
 
 `make all` will run all formatting, linting, and testing.
 

--- a/{{ cookiecutter.__repo_name }}/docker-compose.yml
+++ b/{{ cookiecutter.__repo_name }}/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-common-variables:
   read-only-plugin: &read-only-plugin
     # Buildkite containers assume you mount into /plugin

--- a/{{ cookiecutter.__repo_name }}/docker-compose.yml
+++ b/{{ cookiecutter.__repo_name }}/docker-compose.yml
@@ -16,6 +16,6 @@ services:
       - *read-only-plugin
 
   plugin-tester:
-    image: buildkite/plugin-tester:latest # the only available tag
+    image: buildkite/plugin-tester:v2.0.0
     volumes:
       - *read-only-plugin

--- a/{{ cookiecutter.__repo_name }}/docker-compose.yml
+++ b/{{ cookiecutter.__repo_name }}/docker-compose.yml
@@ -10,7 +10,7 @@ x-common-variables:
 
 services:
   plugin-linter:
-    image: buildkite/plugin-linter:latest # the only available tag
+    image: buildkite/plugin-linter@sha256:833b1ce8326b038c748c8f04d317045205e115b1732a6842ec4a957f550fe357
     command: ["--id", "{{ cookiecutter.github_org }}/{{ cookiecutter.__plugin_name }}"]
     volumes:
       - *read-only-plugin

--- a/{{ cookiecutter.__repo_name }}/tests/checkout.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/checkout.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/command.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/environment.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/environment.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/post-artifact.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/post-artifact.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/post-checkout.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/post-checkout.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/post-command.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/post-command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/pre-artifact.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/pre-artifact.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/pre-checkout.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/pre-checkout.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/pre-command.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/pre-command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty

--- a/{{ cookiecutter.__repo_name }}/tests/pre-exit.bats
+++ b/{{ cookiecutter.__repo_name }}/tests/pre-exit.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export DOCKER_STUB_DEBUG=/dev/tty


### PR DESCRIPTION
There's an official release for [`buildkite/plugin-tester`](https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v2.0.0) now. It updates several bits of BATS infrastructure, but also introduces a breaking change.

This PR locks us to the `v2.0.0` release of the `plugin-tester` image, and addresses the breaking change.

I also noticed that our use of the `buildkite/plugin-linter` image was also pinned to `latest`, just as our `buildkite/plugin-tester` image was. There are no formal release of this image (yet :crossed_fingers:), so I've pinned it to a concrete SHA to be safe.

While making these fixes, I also took the liberty of shifting our Docker Compose usage explicitly to v2, as we have been doing across all our projects lately.