### PR TITLE
Update `vault-login` Buildkite plugin to `v0.1.3`

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -22,7 +22,7 @@ steps:
       command:
         - make lint-build-files
       plugins:
-        - grapl-security/vault-login#v0.1.2
+        - grapl-security/vault-login#v0.1.3
         - grapl-security/vault-env#v0.1.0:
             secrets:
               - buildkite-plugin-cookiecutter/TOOLCHAIN_AUTH_TOKEN
@@ -31,7 +31,7 @@ steps:
       command:
         - make lint-python
       plugins:
-        - grapl-security/vault-login#v0.1.2
+        - grapl-security/vault-login#v0.1.3
         - grapl-security/vault-env#v0.1.0:
             secrets:
               - buildkite-plugin-cookiecutter/TOOLCHAIN_AUTH_TOKEN
@@ -40,7 +40,7 @@ steps:
       command:
         - make lint-shell
       plugins:
-        - grapl-security/vault-login#v0.1.2
+        - grapl-security/vault-login#v0.1.3
         - grapl-security/vault-env#v0.1.0:
             secrets:
               - buildkite-plugin-cookiecutter/TOOLCHAIN_AUTH_TOKEN
@@ -49,7 +49,7 @@ steps:
       command:
         - make typecheck
       plugins:
-        - grapl-security/vault-login#v0.1.2
+        - grapl-security/vault-login#v0.1.3
         - grapl-security/vault-env#v0.1.0:
             secrets:
               - buildkite-plugin-cookiecutter/TOOLCHAIN_AUTH_TOKEN
@@ -61,7 +61,7 @@ steps:
       command:
         - make test-template
       plugins:
-        - grapl-security/vault-login#v0.1.2
+        - grapl-security/vault-login#v0.1.3
         - grapl-security/vault-env#v0.1.0:
             secrets:
               - buildkite-plugin-cookiecutter/TOOLCHAIN_AUTH_TOKEN


### PR DESCRIPTION
Update grapl-security/vault-login Buildkite plugin version to v0.1.3

Picks up additional logging features, specifically https://github.com/grapl-security/vault-login-buildkite-plugin/pull/26

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖