### PR TITLE
Update `buildkite/plugin-tester` to v3.0.0

### DIFF
--- a/{{ cookiecutter.__repo_name }}/docker-compose.yml
+++ b/{{ cookiecutter.__repo_name }}/docker-compose.yml
@@ -14,6 +14,6 @@ services:
       - *read-only-plugin
 
   plugin-tester:
-    image: buildkite/plugin-tester:v2.0.0
+    image: buildkite/plugin-tester:v3.0.0
     volumes:
       - *read-only-plugin


### PR DESCRIPTION
https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v3.0.0

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
