### PR TITLE
Update `buildkite/plugin-tester` to v3.0.1

### DIFF
--- a/{{ cookiecutter.__repo_name }}/docker-compose.yml
+++ b/{{ cookiecutter.__repo_name }}/docker-compose.yml
@@ -14,6 +14,6 @@ services:
       - *read-only-plugin
 
   plugin-tester:
-    image: buildkite/plugin-tester:v3.0.0
+    image: buildkite/plugin-tester:v3.0.1
     volumes:
       - *read-only-plugin


### PR DESCRIPTION
There was a big bug in v3.0.0, but one that the test suite in this
repository didn't trigger. We'll go ahead an update to remove the bug
and remove a potential source of confusion in the future for any new
plugins we create.

- https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v3.0.1
- https://github.com/buildkite-plugins/bats-mock/pull/8

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
